### PR TITLE
MAINT: Remove use of peek method

### DIFF
--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -108,8 +108,8 @@ class File(Group):
     Parameters
     ----------
     filename : str or file-like
-        Name of file (string or unicode) or file like object which have read,
-        seek and peek methods which behaved like a Python file object.
+        Name of file (string or unicode) or file like object which has read
+        and seek methods which behaved like a Python file object.
 
     Attributes
     ----------
@@ -125,9 +125,9 @@ class File(Group):
     def __init__(self, filename):
         """ initalize. """
         if hasattr(filename, 'read'):
-            if not hasattr(filename, 'seek') or not hasattr(filename, 'peek'):
+            if not hasattr(filename, 'seek'):
                 raise ValueError(
-                    'File like object must have a seek and peek method')
+                    'File like object must have a seek method')
             self._fh = filename
         else:
             self._fh = open(filename, 'rb')

--- a/pyfive/low_level.py
+++ b/pyfive/low_level.py
@@ -24,7 +24,8 @@ class SuperBlock(object):
         """ initalize. """
 
         fh.seek(offset)
-        version_hint = struct.unpack_from('<B', fh.peek(9), 8)[0]
+        version_hint = struct.unpack_from('<B', fh.read(9), 8)[0]
+        fh.seek(offset)
         if version_hint == 0:
             contents = _unpack_struct_from_file(SUPERBLOCK_V0, fh)
             self._end_of_sblock = offset + SUPERBLOCK_V0_SIZE
@@ -335,7 +336,8 @@ class DataObjects(object):
     def __init__(self, fh, offset):
         """ initalize. """
         fh.seek(offset)
-        version_hint = struct.unpack_from('<B', fh.peek(1))[0]
+        version_hint = struct.unpack_from('<B', fh.read(1))[0]
+        fh.seek(offset)
         if version_hint == 1:
             msgs, msg_data, header = self._parse_v1_objects(fh)
         elif version_hint == ord('O'):   # first character of v2 signature


### PR DESCRIPTION
Allows reading from BytesIO objects.  Previously this type of object would need
to be wrapped in a BufferedReader.