### PR TITLE
BUG: filename attr set for file-like objects

### DIFF
--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -135,7 +135,7 @@ class File(Group):
     Attributes
     ----------
     filename : str
-        Name of the file on disk.
+        Name of the file on disk, None if not available.
     mode : str
         String indicating that the file is open readonly ("r").
     userblock_size : int
@@ -151,14 +151,15 @@ class File(Group):
                     'File like object must have a seek method')
             self._fh = filename
             self._close = False
+            self.filename = getattr(filename, 'name', None)
         else:
             self._fh = open(filename, 'rb')
             self._close = True
+            self.filename = filename
         self._superblock = SuperBlock(self._fh, 0)
         offset = self._superblock.offset_to_dataobjects
         dataobjects = DataObjects(self._fh, offset)
 
-        self.filename = filename
         self.file = self
         self.mode = 'r'
         self.userblock_size = 0

--- a/tests/test_file_like.py
+++ b/tests/test_file_like.py
@@ -23,6 +23,8 @@ def test_read_latest_fileobj():
     with io.open(LATEST_HDF5_FILE, 'rb') as f:
         with pyfive.File(f) as hfile:
 
+            assert hfile.filename == LATEST_HDF5_FILE
+
             # root
             assert hfile.attrs['attr1'] == -123
             assert hfile.attrs['attr1'].dtype == np.dtype('int32')


### PR DESCRIPTION
The File.filename attribute is set when available when file-like object are
provided to the class.