### PR TITLE
ENH: Dataset.ndim attribute

### DIFF
--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -219,6 +219,8 @@ class Dataset(object):
     fillvalue : float or None
         Value indicating uninitialized portions of the dataset. None is no fill
         values has been defined.
+    dim : int
+        Number of dimensions.
     dims : None
         Dimension scales.
     attrs : dict
@@ -265,6 +267,11 @@ class Dataset(object):
     def shape(self):
         """ shape attribute. """
         return self._dataobjects.shape
+
+    @property
+    def ndim(self):
+        """ number of dimensions. """
+        return len(self.shape)
 
     @property
     def dtype(self):

--- a/tests/test_high_level.py
+++ b/tests/test_high_level.py
@@ -98,6 +98,9 @@ def test_dataset_class():
         assert dset1.shape == (4, )
         assert dset2.shape == (4, )
 
+        assert dset1.ndim == 1
+        assert dset2.ndim == 1
+
         assert dset1.dtype == np.dtype('<i4')
         assert dset2.dtype == np.dtype('>u8')
 


### PR DESCRIPTION
The ndim attribute of the Dataset class report the number of dimensions (rank)
for the dataset.