### PR TITLE
ENH: Dataset.astype method

### DIFF
--- a/tests/test_high_level.py
+++ b/tests/test_high_level.py
@@ -155,3 +155,14 @@ def test_get_objects_by_path():
         assert_raises(KeyError, hfile.__getitem__, 'group1/fake')
         assert_raises(KeyError, hfile.__getitem__, 'group1/subgroup1/fake')
         assert_raises(KeyError, hfile.__getitem__, 'group1/dataset2/fake')
+
+
+def test_astype():
+
+    with pyfive.File(EARLIEST_HDF5_FILE) as hfile:
+        dset1 = hfile['dataset1']
+        assert dset1.dtype == np.dtype('<i4')
+        with dset1.astype('i2'):
+            assert dset1[:].dtype == np.dtype('i2')
+        with dset1.astype('f8'):
+            assert dset1[:].dtype == np.dtype('f8')


### PR DESCRIPTION
The astype Dataset method returns a context manager where data from the dataset
is read as a particular type.  Type conversion is done by NumPy, this differs
from h5py where the conversion is done by the HDF5 library.  Results will be
similar but may differ slightly.