### PR TITLE
ENH: Dataset.read_direct method

### DIFF
--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -282,9 +282,17 @@ class Dataset(object):
             return data
         return data.astype(self._astype)
 
-    def read_direct(self, array, source_sel=None, dset_sel=None):
-        """ Read from a HDF5 dataset directly into a NumPy array. """
-        raise NotImplementedError
+    def read_direct(self, array, source_sel=None, dest_sel=None):
+        """
+        Read from a HDF5 dataset directly into a NumPy array.
+
+        This is equivalent to dset[source_sel] = arr[dset_sel].
+
+        Creation of intermediates is not avoided. This method if provided from
+        compatibility with h5py, it is not efficient.
+
+        """
+        array[dest_sel] = self[source_sel]
 
     def astype(self, dtype):
         """

--- a/tests/test_high_level.py
+++ b/tests/test_high_level.py
@@ -166,3 +166,21 @@ def test_astype():
             assert dset1[:].dtype == np.dtype('i2')
         with dset1.astype('f8'):
             assert dset1[:].dtype == np.dtype('f8')
+
+
+def test_read_direct():
+
+    with pyfive.File(EARLIEST_HDF5_FILE) as hfile:
+        dset1 = hfile['dataset1']
+
+        arr = np.zeros(4)
+        dset1.read_direct(arr)
+        assert_array_equal(arr, [0, 1, 2, 3])
+
+        arr = np.zeros(4)
+        dset1.read_direct(arr, np.s_[:2], np.s_[:2])
+        assert_array_equal(arr, [0, 1, 0, 0])
+
+        arr = np.zeros(4)
+        dset1.read_direct(arr, np.s_[1:3], np.s_[2:])
+        assert_array_equal(arr, [0, 0, 1, 2])


### PR DESCRIPTION
Provide a read_direct method for compatibility with h5py. This method is not
efficient, it does not avoid making intermediates.