### PR TITLE
adding an implementation of SoftLink

### DIFF
--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -77,7 +77,15 @@ class Group(Mapping):
             raise KeyError('%s not found in group' % (next_obj))
 
         obj_name = posixpath.join(self.name, next_obj)
-        dataobjs = DataObjects(self.file._fh, self._links[next_obj])
+        link_target = self._links[next_obj]
+
+        if isinstance(link_target, str):
+            try:
+                return self.__getitem__(link_target)
+            except KeyError:
+                return None
+
+        dataobjs = DataObjects(self.file._fh, link_target)
         if dataobjs.is_dataset:
             if additional_obj != '.':
                 raise KeyError('%s is a dataset, not a group' % (obj_name))

--- a/pyfive/misc_low_level.py
+++ b/pyfive/misc_low_level.py
@@ -107,10 +107,16 @@ class SymbolTable(object):
             entry['link_name'] = link_name
         return
 
-    def get_links(self):
+    def get_links(self, heap):
         """ Return a dictionary of links (dataset/group) and offsets. """
-        return {e['link_name']: e['object_header_address'] for e in
-                self.entries}
+        links = {}
+        for e in self.entries:
+            if e['cache_type'] in [0,1]:
+                links[e['link_name']] = e['object_header_address']
+            elif e['cache_type'] == 2:
+                offset = struct.unpack('<4I', e['scratch'])[0]
+                links[e['link_name']] = heap.get_object_name(offset).decode('utf-8')
+        return links
 
 
 class GlobalHeap(object):


### PR DESCRIPTION
This adds an implementation of resolving SoftLinks.  The variety of SoftLink that appears in SymbolTable.get_links has been tested and works, but I couldn't find any files that contain link messages (0x0002) in the tests or in my typical working files, so that has not been tested (the _get_links_from_link_msgs method in DataObjects)

Implementation notes: soft links are distinguished from hard links by the fact that they are strings, in the 'get' method in high_level.Group class.  If a link is a string (and therefore a soft link) it is sent back to "get" as a string, and if the lookup fails None is returned, as in the spec.