### PR TITLE
adding a test for filter pipeline description v2

### DIFF
--- a/tests/make_filter_pipeline_v2.py
+++ b/tests/make_filter_pipeline_v2.py
@@ -1,0 +1,11 @@
+#! /usr/bin/env python
+""" Create a HDF5 file with filter pipeline description v2. """
+
+import h5py
+import numpy as np
+
+f = h5py.File('filter_pipeline_v2.hdf5', 'w', libver='v108')
+
+f.create_dataset('data', data=np.ones((10,10,10)), chunks=True, compression=9)
+
+f.close()

--- a/tests/test_filter_pipeline_v2.py
+++ b/tests/test_filter_pipeline_v2.py
@@ -1,27 +1,19 @@
 """ Unit tests for pyfive's ability to read a file with filter_pipeline v2
 (as is found in some new netCDF4 files) """
 import os
-import warnings
 
-import numpy as np
-from numpy.testing import assert_array_equal, assert_almost_equal
+from numpy.testing import assert_almost_equal
 
 import pyfive
 
 DIRNAME = os.path.dirname(__file__)
-# test file from: https://github.com/Unidata/netcdf4-python/blob/master/examples/data/prmsl.2011.nc
-NETCDF4_FILE = os.path.join(DIRNAME, 'prmsl.2011.nc')
+FILTER_PIPELINE_V2_FILE = os.path.join(DIRNAME, 'filter_pipeline_v2.hdf5')
 
 
 def test_filter_pipeline_descr_v2():
 
-    with pyfive.File(NETCDF4_FILE) as hfile:
-
-        # group
-        assert 'prmsl' in hfile
-        d = hfile['prmsl']
-        assert d.chunks == (1, 91, 180)
-        assert d.shuffle == True
-        assert d.compression == 'gzip'
-        assert d.shape == (365, 91, 180)
-
+    with pyfive.File(FILTER_PIPELINE_V2_FILE) as hfile:
+        assert 'data' in hfile
+        d = hfile['data']
+        assert d.shape == (10,10,10)
+        assert_almost_equal(d[0,0,0], 1.1)

--- a/tests/test_filter_pipeline_v2.py
+++ b/tests/test_filter_pipeline_v2.py
@@ -1,0 +1,27 @@
+""" Unit tests for pyfive's ability to read a file with filter_pipeline v2
+(as is found in some new netCDF4 files) """
+import os
+import warnings
+
+import numpy as np
+from numpy.testing import assert_array_equal, assert_almost_equal
+
+import pyfive
+
+DIRNAME = os.path.dirname(__file__)
+# test file from: https://github.com/Unidata/netcdf4-python/blob/master/examples/data/prmsl.2011.nc
+NETCDF4_FILE = os.path.join(DIRNAME, 'prmsl.2011.nc')
+
+
+def test_filter_pipeline_descr_v2():
+
+    with pyfive.File(NETCDF4_FILE) as hfile:
+
+        # group
+        assert 'prmsl' in hfile
+        d = hfile['prmsl']
+        assert d.chunks == (1, 91, 180)
+        assert d.shuffle == True
+        assert d.compression == 'gzip'
+        assert d.shape == (365, 91, 180)
+


### PR DESCRIPTION
Here is a test for filter pipeline description version 2, using [a file from the netCDF4 examples](https://github.com/Unidata/netcdf4-python/blob/master/examples/data/prmsl.2011.nc)