### PR TITLE
Remove use of deprecated product function from numpy

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyfive/dataobjects.py
+++ b/pyfive/dataobjects.py
@@ -184,7 +184,7 @@ class DataObjects(object):
 
         # read in the dataspace information
         shape, maxshape = determine_data_shape(self.msg_data, offset)
-        items = int(np.product(shape))
+        items = int(np.prod(shape))
         offset += _padded_size(attr_dict['dataspace_size'], padding_multiple)
 
         # read in the value(s)


### PR DESCRIPTION
Replace use of deprecated `product` function in NumPy is `prod`