### PR TITLE
Empty unlimited chunked variables cause crash

### DIFF
--- a/pyfive/dataobjects.py
+++ b/pyfive/dataobjects.py
@@ -480,6 +480,10 @@ class DataObjects(object):
 
     def _get_chunked_data(self, offset):
         """ Return data which is chunked. """
+
+        if np.prod(self.shape) == 0:
+            return np.empty(self.shape, dtype=self.dtype)
+
         self._get_chunk_params()
         chunk_btree = BTreeV1RawDataChunks(
             self.fh, self._chunk_address, self._chunk_dims)

--- a/tests/make_netcdf_unlimited.py
+++ b/tests/make_netcdf_unlimited.py
@@ -1,0 +1,18 @@
+#! /usr/bin/env python
+""" Create a netcdf file with an unlimited dimension, but no data """
+
+import netCDF4
+import numpy as np
+
+f = netCDF4.Dataset('netcdf4_empty_unlimited.nc', 'w')
+f.createDimension('x', 4)
+f.createDimension('unlimited', None)  # Unlimited dimension
+v = f.createVariable("foo_unlimited", float, ("x", "unlimited"))
+f.close()
+
+f = netCDF4.Dataset('netcdf4_unlimited.nc', 'w')
+f.createDimension('x', 4)
+f.createDimension('unlimited', None)  # Unlimited dimension
+v = f.createVariable("foo_unlimited", float, ("x", "unlimited"))
+v[:] = np.ones((4,1))
+f.close()

--- a/tests/test_netcdf_unlimited.py
+++ b/tests/test_netcdf_unlimited.py
@@ -1,0 +1,43 @@
+""" Unit tests for pyfive's ability to read a NetCDF4 Classic file with an unlimited dimension"""
+import os
+import warnings
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+import pyfive
+
+DIRNAME = os.path.dirname(__file__)
+NETCDF4_UNLIMITED_FILE = os.path.join(DIRNAME, 'netcdf4_unlimited.nc')
+NETCDF4_EMPTY_UNLIMITED_FILE = os.path.join(DIRNAME, 'netcdf4_empty_unlimited.nc')
+H5NETCDF_FILE = os.path.join(DIRNAME, 'h5netcdf_test.hdf5')
+
+def test_read_netcdf4_unlimited():
+    """" This works"""
+
+    with pyfive.File(NETCDF4_UNLIMITED_FILE) as hfile:
+
+        # dataset
+        var1 = hfile['foo_unlimited']
+        assert var1.dtype == np.dtype('<f8')
+        assert_array_equal(var1[:], np.ones((4,1)))
+       
+def test_read_netcdf4_empty_unlimited():
+    "This does not work currently. Why not?"
+    # This is one example of the sort of problem we see with the H6NetCDF file.
+    with pyfive.File(NETCDF4_EMPTY_UNLIMITED_FILE) as hfile:
+
+        # dataset
+        var1 = hfile['foo_unlimited']
+        assert var1.dtype == np.dtype('<f8')
+        print (var1[:])
+
+def test_h5netcdf_file():
+    """ This doesn't work either. Why not? """
+
+    with pyfive.File(H5NETCDF_FILE) as hfile:
+
+        # dataset
+        var1 = hfile['empty']
+        print(var1.shape)
+        print(var1[:])


### PR DESCRIPTION
If ones has created a variable which is intended to be chunked, but it is currently empty, when the file is read, we get a stack dump that ends with this:
```
    def _read_node_header(self, offset, node_level):
        """ Return a single node header in the b-tree located at a give offset. """
>       self.fh.seek(offset)
E       ValueError: cannot fit 'int' into an offset-sized integer
```

This pull request includes code to create a file which manifests the problem, a test to expose it, and a fix.