### PR TITLE
remove pin on netcdf4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ test = [
     "flask-cors",
     "h5netcdf",
     "h5py",
-    "netCDF4<1.7.3",  # github.com/NCAS-CMS/pyfive/issues/123; remove when on conda-forge
+    "netCDF4",
     "moto",
     "s3fs>=2025.9.0",  # v-mismatch with boto3 results in ancient s3fs
 ]


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

netCDF4==1.7.3 built and deployed on conda-forge so we need to remove the pin in pyproject.toml since now we end up with an older package, and from PyPI on top of it

https://anaconda.org/conda-forge/netcdf4

## Before you get started


## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [x] All tests pass
