### PR TITLE
fix fletcher32, add tests

### DIFF
--- a/pyfive/btree.py
+++ b/pyfive/btree.py
@@ -242,15 +242,13 @@ class BTreeV1RawDataChunks(BTreeV1):
             arr = np.frombuffer(chunk_buffer[:-4]+b'\x00', '<u2')
         else:
             arr = np.frombuffer(chunk_buffer[:-4], '<u2')
-        sum1 = sum2 = 0
+        sum1 = sum2 = np.uint32(0)
         for i in arr:
             sum1 = (sum1 + i) % 65535
             sum2 = (sum2 + sum1) % 65535
 
         # extract stored checksums
         ref_sum1, ref_sum2 = np.frombuffer(chunk_buffer[-4:], '>u2')
-        ref_sum1 = ref_sum1 % 65535
-        ref_sum2 = ref_sum2 % 65535
 
         # compare
         if sum1 != ref_sum1 or sum2 != ref_sum2:


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This fixes the current implementation of the fletcher32 algorithm. The current testsuite didn't catch it, I only found it by accident while running the xarray testsuite. It therefore also adds a comprehensive test matrix to run over different filter pipelines including chunking, compression, fletcher32 and shuffle.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #128


## Before you get started

- [x] [☝ Create an issue](https://github.com/NCAS-CMS/pyfive/issues) to discuss what you are going to do

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Unit tests have been added (if codecov test fails)
- [ ] Any changed dependencies have been added or removed correctly (if need be)
- [ ] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [x] All tests pass
