### PR TITLE
pin numpy>=2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - numpy
+  - numpy >=2
   - python >=3.10
   # testing
   - h5py  # link to same hdf5 lib with netcdf4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "numpy",
+    "numpy>=2",
 ]
 description = "A pure python HDF5 reader"
 license = {text = "BSD License, Version 3-Clause"}


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Numpy<2 (1.26.4 ie last <2 version) is starting to be a nuisance from packages that don't explicitly pin to >=2, and a very very old type.

## Before you get started

- [ ] [☝ Create an issue](https://github.com/NCAS-CMS/pyfive/issues) to discuss what you are going to do

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [x] All tests pass
