### PR TITLE
[DNM] Activate and test pre-commit.ci

### DIFF
--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -18,6 +18,7 @@ from pyfive.misc_low_level import SuperBlock
 from pyfive.h5py import Datatype
 
 
+#test see pre-commit.ci in action
 class Group(Mapping):
     """
     An HDF5 Group which may hold attributes, datasets, or other groups.


### PR DESCRIPTION
I have activated pre-commit.ci app to run in our repo, and this is to test it's doing the right thing.
https://pre-commit.ci/

@davidhassell @bnlawrence @kmuehlbauer @dostuffthatmatters gents, yet another step towards making our repo rather modern, and user-facing - I turned on pre-commit.ci that looks like this when somebody opens a PR https://results.pre-commit.ci/run/github/57862445/1769523801.CpvXywnoSiia7JTvu6TYwg - nice results displayed via a nice GUI; of course, this should be picked up and fixed by the OP of the PR, but there are many reasons why the OP isn't running `pre-commit run -a` in their repo. The GHA CI still runs pre-commit since that's still needed for nightly tests etc.

NOTE: the actual pytest tests are failing since the CEDA S3 bucket is offline, there is maintenance at JASMIN happening today :construction: 