### PR TITLE
Skip tests if ceda-jasmin s3 storage is offline

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import s3fs
 import json
 import pytest
+import requests
 
 from moto.moto_server.threaded_moto_server import ThreadedMotoServer
 
@@ -13,6 +14,18 @@ endpoint_uri = "http://127.0.0.1:%s/" % port
 test_bucket_name = "test"
 versioned_bucket_name = "test-versioned"
 secure_bucket_name = "test-secure"
+
+
+def s3_url_exists(url: str) -> bool:
+    try:
+        response = requests.get(
+            url,
+            timeout=10,  # seconds
+        )
+    except requests.exceptions.RequestException:
+        return False
+    else:
+        return response.status_code == 200
 
 
 def get_boto3_client():

--- a/tests/test_buffer_issue.py
+++ b/tests/test_buffer_issue.py
@@ -1,7 +1,10 @@
 import os
 
 import pyfive
+import pytest
 import s3fs
+
+from conftest import s3_url_exists
 
 
 def _load_nc_file(ncvar):
@@ -26,6 +29,10 @@ def _load_nc_file(ncvar):
     return ds
 
 
+JASMIN_ONLINE = s3_url_exists("https://uor-aces-o.s3-ext.jc.rl.ac.uk")
+
+
+@pytest.mark.skipif(not JASMIN_ONLINE, reason="CEDA S3 object store offline.")
 def test_buffer_issue():
     """
     Test the case when the attribute contains no data.

--- a/tests/test_buffer_issue.py
+++ b/tests/test_buffer_issue.py
@@ -29,7 +29,7 @@ def _load_nc_file(ncvar):
     return ds
 
 
-JASMIN_ONLINE = s3_url_exists("https://uor-aces-o.s3-ext.jc.rl.ac.uk")
+JASMIN_ONLINE = s3_url_exists("https://uor-aces-o.s3-ext.jc.rl.ac.uk/esmvaltool-zarr")
 
 
 @pytest.mark.skipif(not JASMIN_ONLINE, reason="CEDA S3 object store offline.")


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

We should skip those tests, otherwise `requests` goes into a long loop that will eventually fail, note that I've not used a pytest fixture for it so we can simply pop boolean variables in pytest markers.


## Before you get started

- [ ] [☝ Create an issue](https://github.com/NCAS-CMS/pyfive/issues) to discuss what you are going to do

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Unit tests have been added (if codecov test fails)
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [ ] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [x] All tests pass
