### PR TITLE
Adds support for more types of FractalHeap (used for storing attributes)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
+        exclude: ^tests/data/cmip_bad_eg\.nc$
       - id: check-ast
       - id: check-case-conflict
       - id: check-merge-conflict

--- a/pyfive/btree.py
+++ b/pyfive/btree.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from .core import _unpack_struct_from_file
 from .core import _unpack_struct_from
+from .core import _unpack_integer
 
 
 class AbstractBTree(object):
@@ -538,6 +539,41 @@ class BTreeV2AttrNames(BTreeV2):
 
     def _parse_record(self, record):
         return _unpack_struct_from(V2_BTREE_NODE_TYPE_8_LAYOUT, record)
+
+
+class BTreeV2HugeObjectsIndirect(BTreeV2):
+    """
+    HDF5 version 2 B-Tree storing indirectly accessed, non-filtered huge objects.
+
+    Record layout (type 1):
+    - huge object address
+    - huge object length
+    - huge object ID (lookup key)
+    """
+
+    NODE_TYPE = 1  # type: ignore[assignment]
+
+    def __init__(self, fh, offset, sizeof_offsets, sizeof_lengths):
+        self._sizeof_offsets = sizeof_offsets
+        self._sizeof_lengths = sizeof_lengths
+        super().__init__(fh, offset)
+
+    def _parse_record(self, record):
+        rec_offset = _unpack_integer(self._sizeof_offsets, record, 0)
+        rec_length = _unpack_integer(self._sizeof_lengths, record, self._sizeof_offsets)
+        rec_id = _unpack_integer(
+            self._sizeof_lengths,
+            record,
+            self._sizeof_offsets + self._sizeof_lengths,
+        )
+        return {"address": rec_offset, "length": rec_length, "id": rec_id}
+
+    def find(self, huge_object_id):
+        """Return the record matching a huge-object ID/key."""
+        for record in self.iter_records():
+            if record["id"] == huge_object_id:
+                return record
+        raise KeyError(f"Huge object ID not found in v2 B-tree: {huge_object_id}")
 
 
 # IV.A.2.l The Data Storage - Filter Pipeline message

--- a/pyfive/btree.py
+++ b/pyfive/btree.py
@@ -556,6 +556,7 @@ class BTreeV2HugeObjectsIndirect(BTreeV2):
     def __init__(self, fh, offset, sizeof_offsets, sizeof_lengths):
         self._sizeof_offsets = sizeof_offsets
         self._sizeof_lengths = sizeof_lengths
+        self.record_by_id = {}
         super().__init__(fh, offset)
 
     def _parse_record(self, record):
@@ -570,10 +571,16 @@ class BTreeV2HugeObjectsIndirect(BTreeV2):
 
     def find(self, huge_object_id):
         """Return the record matching a huge-object ID/key."""
-        for record in self.iter_records():
-            if record["id"] == huge_object_id:
-                return record
-        raise KeyError(f"Huge object ID not found in v2 B-tree: {huge_object_id}")
+        # read the b-tree and cache.
+        if self.record_by_id == {}:
+            for record in self.iter_records():
+                self.record_by_id[record["id"]] = record
+        try:
+            return self.record_by_id[huge_object_id]
+        except KeyError as e:
+            raise KeyError(
+                f"Huge object ID not found in v2 B-tree: {huge_object_id}"
+            ) from e
 
 
 # IV.A.2.l The Data Storage - Filter Pipeline message

--- a/pyfive/misc_low_level.py
+++ b/pyfive/misc_low_level.py
@@ -12,6 +12,7 @@ from .core import _unpack_integer
 from .core import InvalidHDF5File
 from .core import UNDEFINED_ADDRESS
 from .core import Reference
+from .btree import BTreeV2HugeObjectsIndirect
 from math import prod
 import numpy as np
 
@@ -226,21 +227,70 @@ class FractalHeap(object):
         Read the heap header and construct the linear block mapping
         """
         # fh = Interceptor(fh)
+        self.fh = fh
         fh.seek(offset)
         header = _unpack_struct_from_file(FRACTAL_HEAP_HEADER, fh)
         assert header["signature"] == b"FRHP"
         assert header["version"] == 0
+
+        # Only 64-bit offsets/lengths are currently supported by pyfive.
+        self._sizeof_offsets = 8
+        self._sizeof_lengths = 8
+        heap_id_len = header["object_index_size"]
+        direct_unfiltered_id_size = 1 + self._sizeof_offsets + self._sizeof_lengths
+        direct_filtered_id_size = direct_unfiltered_id_size + 4 + self._sizeof_lengths
+
+        self._huge_ids_are_filtered = header["filter_info_size"] > 0
+        self.huge_ids_are_filtered = self._huge_ids_are_filtered
+        if self._huge_ids_are_filtered:
+            self._huge_ids_are_direct = heap_id_len >= direct_filtered_id_size
+        else:
+            self._huge_ids_are_direct = heap_id_len >= direct_unfiltered_id_size
+        self.huge_ids_are_direct = self._huge_ids_are_direct
+
+        # For indirectly accessed huge objects, the key stored in the heap ID
+        # may be smaller than the file's length-size; HDF5 bounds it by
+        # min(id_len - 1, sizeof(hsize_t)).
+        if self._huge_ids_are_direct:
+            self._huge_id_size = self._sizeof_lengths
+        else:
+            self._huge_id_size = min(heap_id_len - 1, 8)
+
+        self._huge_btree = None
+
+        # Tiny objects are stored directly in the heap ID.
+        # HDF5 uses two tiny-ID encodings:
+        # - normal: low 4 bits of first byte store (length - 1)
+        # - extended: low 4 bits plus a second byte store (length - 1)
+        tiny_len_short = 16
+        if (heap_id_len - 1) <= tiny_len_short:
+            self._tiny_max_len = heap_id_len - 1
+            self._tiny_len_extended = False
+        elif (heap_id_len - 1) == (tiny_len_short + 1):
+            self._tiny_max_len = tiny_len_short
+            self._tiny_len_extended = False
+        else:
+            self._tiny_max_len = heap_id_len - 2
+            self._tiny_len_extended = True
 
         if header["filter_info_size"]:
             raise NotImplementedError
 
         if header["btree_address_huge_objects"] == UNDEFINED_ADDRESS:
             header["btree_address_huge_objects"] = None
-        else:
-            raise NotImplementedError
 
         if header["root_block_address"] == UNDEFINED_ADDRESS:
             header["root_block_address"] = None
+
+        if (not self._huge_ids_are_direct) and header[
+            "btree_address_huge_objects"
+        ] is not None:
+            self._huge_btree = BTreeV2HugeObjectsIndirect(
+                fh,
+                header["btree_address_huge_objects"],
+                self._sizeof_offsets,
+                self._sizeof_lengths,
+            )
 
         nbits = header["log2_maximum_heap_size"]
         block_offset_size = self._min_size_nbits(nbits)
@@ -367,10 +417,43 @@ class FractalHeap(object):
 
                 return None
 
-            case 1:  # tiny
-                raise NotImplementedError
-            case 2:  # huge
-                raise NotImplementedError
+            case 1:  # huge
+                assert version == 0
+                # Determine the sub-type from the heap header flags / ID length
+                # The sub-type is determined at heap-construction time by checking
+                # whether (offset_size + length_size + 1) fits in the heap ID length.
+                # The HDF5 library uses a heuristic: if the total size of address+length
+                # fits in the heap ID, it's "direct"; otherwise "indirect".
+                if self._huge_ids_are_direct:
+                    # Sub-type 3 or 4: address and length embedded in the ID
+                    addr = _unpack_integer(self._sizeof_offsets, heapid, data_offset)
+                    data_offset += self._sizeof_offsets
+                    length = _unpack_integer(self._sizeof_lengths, heapid, data_offset)
+                    if self._huge_ids_are_filtered:
+                        raise NotImplementedError
+                    else:
+                        self.fh.seek(addr)
+                        return self.fh.read(length)
+                else:
+                    # Sub-type 1 or 2: look up via v2 B-tree
+                    if self._huge_btree is None:
+                        raise NotImplementedError
+                    key = _unpack_integer(self._huge_id_size, heapid, data_offset)
+                    record = self._huge_btree.find(key)
+                    self.fh.seek(record["address"])
+                    data = self.fh.read(record["length"])
+                    if self._huge_ids_are_filtered:
+                        raise NotImplementedError
+                    return data
+            case 2:  # tiny
+                assert version == 0
+                if self._tiny_len_extended:
+                    encoded_size = heapid[data_offset] | ((firstbyte & 15) << 8)
+                    data_offset += 1
+                else:
+                    encoded_size = firstbyte & 15
+                size = encoded_size + 1
+                return heapid[data_offset : data_offset + size]
             case _:
                 raise NotImplementedError
 

--- a/tests/test_fractal_heap.py
+++ b/tests/test_fractal_heap.py
@@ -17,7 +17,7 @@ def name(tmp_path_factory):
 @pytest.mark.parametrize("payload_size", [4033, 4032])
 @pytest.mark.parametrize("n_attrs", [10, 11])
 def test_huge_object(name, payload_size, n_attrs):
-    """Tests simpe huge objects"""
+    """Tests simple huge objects"""
     err = nullcontext()
 
     with h5py.File(name, "w", track_order=True) as f:

--- a/tests/test_fractal_heap.py
+++ b/tests/test_fractal_heap.py
@@ -3,6 +3,10 @@ import h5py
 import pytest
 from contextlib import nullcontext
 import pyfive
+from pathlib import Path
+
+DATA_DIR = Path(__file__).parent / "data"
+CMIP_BIG_HEAP_FILE = DATA_DIR / "cmip_bad_eg.nc"
 
 
 @pytest.fixture(scope="module")
@@ -13,14 +17,8 @@ def name(tmp_path_factory):
 @pytest.mark.parametrize("payload_size", [4033, 4032])
 @pytest.mark.parametrize("n_attrs", [10, 11])
 def test_huge_object(name, payload_size, n_attrs):
-    # 4032/4033 is the huge object treshold
-    # it kicks in, if we have more than 10 attributes
-    # todo, this needs more check,
-    #  might depend on heap sizes and other figures
-    if payload_size == 4033 and n_attrs == 11:
-        err = pytest.raises(NotImplementedError)
-    else:
-        err = nullcontext()
+    """Tests simpe huge objects"""
+    err = nullcontext()
 
     with h5py.File(name, "w", track_order=True) as f:
         for i in range(n_attrs):
@@ -88,3 +86,43 @@ def test_fractal_heap(name, n_attrs):
 
     for k, v in attrs.items():
         np.testing.assert_equal(v, attrs2[k])
+
+
+def test_tiny_object(name):
+    """Haven't been able to create a file with tiny objects, so we test the decoding directly"""
+    heap = pyfive.misc_low_level.FractalHeap.__new__(pyfive.misc_low_level.FractalHeap)
+
+    # Normal tiny encoding: 1 flag byte + payload.
+    payload = b"abcde"
+    heap._tiny_len_extended = False
+    heap.managed = b""
+    heap.blocks = []
+    heap.fh = None
+    heapid = bytes([0x20 | (len(payload) - 1)]) + payload
+    assert heap.get_data(heapid) == payload
+
+    # Extended tiny encoding: 2 flag bytes + payload.
+    payload = b"abcdefghijklmnopqr"
+    heap._tiny_len_extended = True
+    encoded_size = len(payload) - 1
+    heapid = (
+        bytes([0x20 | ((encoded_size & 0x0F00) >> 8), encoded_size & 0x00FF]) + payload
+    )
+    assert heap.get_data(heapid) == payload
+
+
+def test_huge_cmip_payload():
+    """Test reading a huge object from a real file known to exercise the heap object with a b-tree index"""
+    if not CMIP_BIG_HEAP_FILE.exists():
+        pytest.skip("cmip_bad_eg.nc fixture not present locally")
+
+    with pyfive.File(CMIP_BIG_HEAP_FILE, "r") as f:
+        attrs = f.attrs
+        print(attrs.keys())
+        assert "history" in attrs
+        assert len(attrs["history"]) > 200
+        mip_era = attrs["mip_era"]
+        if isinstance(mip_era, (bytes, np.bytes_)):
+            mip_era = mip_era.decode("utf-8")
+        assert mip_era == "CMIP6"
+        assert attrs.get("fred") is None

--- a/tests/test_fractal_heap.py
+++ b/tests/test_fractal_heap.py
@@ -122,7 +122,5 @@ def test_huge_cmip_payload():
         assert "history" in attrs
         assert len(attrs["history"]) > 200
         mip_era = attrs["mip_era"]
-        if isinstance(mip_era, (bytes, np.bytes_)):
-            mip_era = mip_era.decode("utf-8")
-        assert mip_era == "CMIP6"
+        assert str(mip_era) == "b'CMIP6'"
         assert attrs.get("fred") is None


### PR DESCRIPTION
## Description

This pull request includes implementation and tests for two types of FractalHeap which we had not previously encountered (as described in #243).

In practice we have added some more code within the implementation of the `Fractal_Heap` class, which replaces some "NotImplementedError" branches, and support for the particular kind of b-tree used in the fractal heaps.  One large test file which requires one of the two new branches is included - we couldn't shrink it as any attempt to rewrite it invoked a differnt kind of FractalHeap.  We have not been able to generate a real file using the other branch, so some synthetic testing has been included.

Closes #243

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Unit tests have been added (if codecov test fails)
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [ ] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [x] All tests pass
